### PR TITLE
Made import/no-extraneous-dependencies look for every test directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
     'import/no-extraneous-dependencies': [RULE_ON,
       {
         devDependencies: [
-          'test/**',
+          '**/test/**',
           '**/*{test,spec}.js',
         ]
       }

--- a/lib/overrides.js
+++ b/lib/overrides.js
@@ -6,7 +6,7 @@ module.exports = {
   overrides: [
     {
       files: [
-        'test/**'
+        '**/test/**'
       ],
       rules: {
         'node/no-unpublished-require': RULE_OFF,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@squadcraft/eslint-config-squadcraft",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@squadcraft/eslint-config-squadcraft",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "eslint for squadcraft",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Previously it looked for a test directory only in the root directory, now it should look inside every directory in a project